### PR TITLE
Add support for preprocessed elevation data DTM and DOM from hoydedata.no

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ A java downloader for http://data.kartverket.no/download/ ,  https://download.ge
   });
 
   // download using free and open National Elevation Models from hoydedata.no
-   Downloader hoydedata = new Hoydedata();
-   hoydedata.setUtmzone("33");
-   hoydedata.dataset("DTM50");
-   hoydedata.download((fileName,in) -> { # or implement Receiver
+  Downloader hoydedata = new Hoydedata();
+  hoydedata.setUtmzone("33");
+  hoydedata.dataset("DTM50");
+  hoydedata.download((fileName,in) -> { # or implement Receiver
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # jskdata
 
-A java downloader for http://data.kartverket.no/download/ ,  https://download.geonorge.no/skdl2/ and [GeoNorge Download API](https://www.geonorge.no/for-utviklere/APIer-og-grensesnitt/nedlastingsapiet/).
+A java downloader for http://data.kartverket.no/download/ ,  https://download.geonorge.no/skdl2/,
+[GeoNorge Download API](https://www.geonorge.no/for-utviklere/APIer-og-grensesnitt/nedlastingsapiet/) and
+[Hoydedata] (http://www.hoydedata.no/Laserinnsyn).
 
 ## Maven
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ A java downloader for http://data.kartverket.no/download/ ,  https://download.ge
   gndlapia.dataset("6e05aefb-f90e-4c7d-9fb9-299574d0bbf6");
   gndlapia.download((fileName, in) -> { # or implement Receiver
   });
-  
+
+  // download using free and open National Elevation Models from hoydedata.no
+   Downloader hoydedata = new Hoydedata();
+   hoydedata.setUtmzone("33");
+   hoydedata.dataset("DTM50");
+   hoydedata.download((fileName,in) -> { # or implement Receiver
 ```
 
 ## Test

--- a/src/main/java/no/jskdata/Downloader.java
+++ b/src/main/java/no/jskdata/Downloader.java
@@ -73,6 +73,8 @@ public abstract class Downloader {
             dl = new GeoNorgeSkdl2(username, password);
         } else if (type.equals("GeoNorgeDownloadAPI")) {
             dl = new GeoNorgeDownloadAPI(username, password);
+        } else if (type.equals("hoydedata.no")) {
+            dl = new Hoydedata();
         }
 
         String dataset = options.get("dataset");

--- a/src/main/java/no/jskdata/Hoydedata.java
+++ b/src/main/java/no/jskdata/Hoydedata.java
@@ -19,11 +19,9 @@ import org.jsoup.select.Elements;
  */
 public class Hoydedata extends Downloader {
 
-    private String utmzone = "33";
+    private String utmzone = "33"; // default fallback UTM Zone (EUREF-89)
     private final Set<String> datasetIds = new HashSet<>();
     private final String baseUrl = "https://hoydedata.no/LaserInnsyn/";
-
-    //private final List<String> datasets = new ArrayList<String>() {"DTM1","DOM1","DTM10","DOM10","DTM50","DOM50"};
 
     public Hoydedata() {
     }
@@ -31,6 +29,7 @@ public class Hoydedata extends Downloader {
     public void setUtmzone(String utmzone) {
         this.utmzone = utmzone;
     }
+
     public void dataset(String datasetId) {
         datasetIds.add(datasetId);
     }
@@ -62,6 +61,10 @@ public class Hoydedata extends Downloader {
 
 
         }
+    }
+
+    public List<File> getFilesforDataset(String datasetId) throws IOException {
+        return getFilesforDataset(datasetId,this.utmzone);
     }
 
     public List<File> getFilesforDataset(String datasetId,String utmzone) throws IOException {

--- a/src/main/java/no/jskdata/Hoydedata.java
+++ b/src/main/java/no/jskdata/Hoydedata.java
@@ -77,11 +77,22 @@ public class Hoydedata extends Downloader {
                     continue;
                 }
                 String fileId = links.first().text();
+                // Exact match for DTM10,DOM10,DTM50,DOM50
+                boolean found=false;
+                String downloadUrl = null;
+                String fileSize = null;
+                String fileName = null;
                 if (datasetId.equals(fileId)) {
+                    found=true;
+                    fileName = datasetId+"-"+utmzone+".zip";
+                } else if (fileId.substring(0,5).equals(datasetId+" ")) {
+                    found = true;
+                    fileName = fileId.replace(" ","_")+"-"+utmzone+".zip";
+                }
+                if (found) {
                     File fil = new File();
-                    fil.downloadUrl = links.first().attr("abs:href").trim();
-                    fil.name = datasetId+"-"+utmzone+".zip";
-                    //fil.fileSize =
+                    fil.downloadUrl = links.first().attr("abs:href").trim();;
+                    fil.name = fileName;
                     if (cols.size() == 2) {
                         fil.fileSize = cols.get(1).text();
                     }

--- a/src/main/java/no/jskdata/Hoydedata.java
+++ b/src/main/java/no/jskdata/Hoydedata.java
@@ -1,0 +1,97 @@
+package no.jskdata;
+
+import no.jskdata.Downloader;
+import no.jskdata.data.geonorge.File;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.*;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * Java wrapper around https://hoydedata.no/Laserinnsyn
+ */
+public class Hoydedata extends Downloader {
+
+    private String utmzone = "33";
+    private final Set<String> datasetIds = new HashSet<>();
+    private final String baseUrl = "https://hoydedata.no/LaserInnsyn/";
+
+    //private final List<String> datasets = new ArrayList<String>() {"DTM1","DOM1","DTM10","DOM10","DTM50","DOM50"};
+
+    public Hoydedata() {
+    }
+
+    public void setUtmzone(String utmzone) {
+        this.utmzone = utmzone;
+    }
+    public void dataset(String datasetId) {
+        datasetIds.add(datasetId);
+    }
+    public void clear() {
+        datasetIds.clear();
+    }
+
+    private HttpURLConnection openConnectionWithoutCookies(String url) throws IOException {
+        return (HttpURLConnection) new URL(url).openConnection();
+    }
+
+    @Override
+    public void download(Receiver receiver) throws IOException {
+        for (String datasetId : datasetIds) {
+            if (receiver.shouldStop()) {
+                break;
+            }
+            List<File> datasetFiles = getFilesforDataset(datasetId,utmzone);
+            if (datasetFiles.isEmpty()) {
+                break;
+            }
+            for (File file:datasetFiles) {
+                HttpURLConnection conn = openConnectionWithoutCookies(file.downloadUrl);
+                if (conn.getResponseCode() == 200) {
+                    receiver.receive(file.name, conn.getInputStream());
+                    continue;
+                }
+            }
+
+
+        }
+    }
+
+    public List<File> getFilesforDataset(String datasetId,String utmzone) throws IOException {
+        List<File> files = new ArrayList<File>();
+        Connection.Response r = Jsoup.connect(baseUrl).execute();
+        Document d = r.parse();
+        Elements dlContent = d.getElementsByClass("dlContent sone"+utmzone);
+        for(Element row:dlContent) {
+            Elements cols = row.getElementsByTag("td");
+            if (cols.size() > 1) {
+                Elements links = cols.get(0).select("a[href]");
+                if (links.size() <1) {
+                    continue;
+                }
+                String fileId = links.first().text();
+                if (datasetId.equals(fileId)) {
+                    File fil = new File();
+                    fil.downloadUrl = links.first().attr("abs:href").trim();
+                    fil.name = datasetId+"-"+utmzone+".zip";
+                    //fil.fileSize =
+                    if (cols.size() == 2) {
+                        fil.fileSize = cols.get(1).text();
+                    }
+                    files.add(fil);
+                }
+            } else {
+                continue;
+            }
+        }
+        return files;
+    }
+
+}

--- a/src/test/java/no/jskdata/HoydedataTest.java
+++ b/src/test/java/no/jskdata/HoydedataTest.java
@@ -13,7 +13,7 @@ public class HoydedataTest extends DownloaderTestCase {
 
     public void testGetFilelistForDataset() throws IOException{
         Hoydedata h = new Hoydedata();
-        List<File> files = h.getFilesforDataset("DTM50","33");
+        List<String> files = h.getFilesforDataset("DTM50","33");
         //expecting 1 file
         assertNotNull(files);
         assertFalse(files.isEmpty());
@@ -21,7 +21,7 @@ public class HoydedataTest extends DownloaderTestCase {
 
     public void testGetFilelistForLargeDataset() throws IOException {
         Hoydedata h = new Hoydedata();
-        List<File> files = h.getFilesforDataset("DTM1","33");
+        List<String> files = h.getFilesforDataset("DTM1","33");
         assertNotNull(files);
         assertFalse(files.isEmpty());
         assertTrue(files.size()>10);

--- a/src/test/java/no/jskdata/HoydedataTest.java
+++ b/src/test/java/no/jskdata/HoydedataTest.java
@@ -1,0 +1,66 @@
+package no.jskdata;
+
+import com.google.common.io.ByteStreams;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import no.jskdata.data.geonorge.File;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Created by Grotan_Bjorn_Ove on 19.12.2017.
+ */
+public class HoydedataTest extends DownloaderTestCase {
+
+    public void testGetFilelistForDataset() throws IOException{
+        Hoydedata h = new Hoydedata();
+        List<File> files = h.getFilesforDataset("DTM50","33");
+        //expecting 1 file
+        assertNotNull(files);
+        assertFalse(files.isEmpty());
+    }
+
+
+
+    public void testDownloadOneDataset() throws IOException {
+        Set<String> fileNames = new HashSet<>();
+        // test single file
+        fileNames.clear();
+
+        Hoydedata h = new Hoydedata();
+        h.setUtmzone("33");
+        h.dataset("DTM50");
+        h.download(new DefaultReceiver() {
+
+            @Override
+            public void receive(String fileName, InputStream in) throws IOException {
+                assertFalse(fileNames.contains(fileName));
+                fileNames.add(fileName);
+                ByteStreams.exhaust(in);
+            }
+        });
+        assertEquals(1, fileNames.size());
+        h.clear();
+    }
+    public void testDownloadTwoDatasets() throws IOException {
+        Set<String> fileNames = new HashSet<>();
+        Hoydedata h = new Hoydedata();
+        h.setUtmzone("33");
+        h.dataset("DTM50");
+        h.dataset("DOM50");
+        h.download(new DefaultReceiver() {
+
+            @Override
+            public void receive(String fileName, InputStream in) throws IOException {
+                assertFalse(fileNames.contains(fileName));
+                fileNames.add(fileName);
+                ByteStreams.exhaust(in);
+            }
+        });
+        assertEquals(2, fileNames.size());
+        h.clear();
+    }
+}

--- a/src/test/java/no/jskdata/HoydedataTest.java
+++ b/src/test/java/no/jskdata/HoydedataTest.java
@@ -1,7 +1,6 @@
 package no.jskdata;
 
 import com.google.common.io.ByteStreams;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import no.jskdata.data.geonorge.File;
 
 import java.io.IOException;
@@ -10,9 +9,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Created by Grotan_Bjorn_Ove on 19.12.2017.
- */
 public class HoydedataTest extends DownloaderTestCase {
 
     public void testGetFilelistForDataset() throws IOException{
@@ -23,7 +19,13 @@ public class HoydedataTest extends DownloaderTestCase {
         assertFalse(files.isEmpty());
     }
 
-
+    public void testGetFilelistForLargeDataset() throws IOException {
+        Hoydedata h = new Hoydedata();
+        List<File> files = h.getFilesforDataset("DTM1","33");
+        assertNotNull(files);
+        assertFalse(files.isEmpty());
+        assertTrue(files.size()>10);
+    }
 
     public void testDownloadOneDataset() throws IOException {
         Set<String> fileNames = new HashSet<>();
@@ -45,6 +47,7 @@ public class HoydedataTest extends DownloaderTestCase {
         assertEquals(1, fileNames.size());
         h.clear();
     }
+
     public void testDownloadTwoDatasets() throws IOException {
         Set<String> fileNames = new HashSet<>();
         Hoydedata h = new Hoydedata();
@@ -63,4 +66,5 @@ public class HoydedataTest extends DownloaderTestCase {
         assertEquals(2, fileNames.size());
         h.clear();
     }
+
 }

--- a/src/test/java/no/jskdata/HoydedataTest.java
+++ b/src/test/java/no/jskdata/HoydedataTest.java
@@ -29,11 +29,8 @@ public class HoydedataTest extends DownloaderTestCase {
 
     public void testDownloadOneDataset() throws IOException {
         Set<String> fileNames = new HashSet<>();
-        // test single file
-        fileNames.clear();
 
         Hoydedata h = new Hoydedata();
-        h.setUtmzone("33");
         h.dataset("DTM50");
         h.download(new DefaultReceiver() {
 
@@ -51,7 +48,6 @@ public class HoydedataTest extends DownloaderTestCase {
     public void testDownloadTwoDatasets() throws IOException {
         Set<String> fileNames = new HashSet<>();
         Hoydedata h = new Hoydedata();
-        h.setUtmzone("33");
         h.dataset("DTM50");
         h.dataset("DOM50");
         h.download(new DefaultReceiver() {


### PR DESCRIPTION
Supported datums: UTM32,UTM33,UTM35
Supported elevation series: DTM and DOM for grids 50 meter, 10 meter and 1 meter